### PR TITLE
View only: Matroid patch: add support for writing additional metadata to filename

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -2117,6 +2117,7 @@ static void do_streamcopy(InputStream *ist, OutputStream *ost, const AVPacket *p
     } else
         opkt.dts = av_rescale_q(pkt->dts, ist->st->time_base, ost->mux_timebase);
     opkt.dts -= ost_tb_start_time;
+    opkt.gts = pkt->gts;
 
     opkt.duration = av_rescale_q(pkt->duration, ist->st->time_base, ost->mux_timebase);
 

--- a/libavcodec/avpacket.c
+++ b/libavcodec/avpacket.c
@@ -37,6 +37,7 @@ void av_init_packet(AVPacket *pkt)
     pkt->pts                  = AV_NOPTS_VALUE;
     pkt->dts                  = AV_NOPTS_VALUE;
     pkt->pos                  = -1;
+    pkt->gts                  = -1;
     pkt->duration             = 0;
 #if FF_API_CONVERGENCE_DURATION
 FF_DISABLE_DEPRECATION_WARNINGS
@@ -575,6 +576,7 @@ int av_packet_copy_props(AVPacket *dst, const AVPacket *src)
 
     dst->pts                  = src->pts;
     dst->dts                  = src->dts;
+    dst->gts                  = src->gts;
     dst->pos                  = src->pos;
     dst->duration             = src->duration;
 #if FF_API_CONVERGENCE_DURATION

--- a/libavcodec/decode.c
+++ b/libavcodec/decode.c
@@ -1757,6 +1757,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
         frame->pkt_pos      = pkt->pos;
         frame->pkt_duration = pkt->duration;
         frame->pkt_size     = pkt->size;
+        frame->gts          = pkt->gts;
 
         for (i = 0; i < FF_ARRAY_ELEMS(sd); i++) {
             int size;

--- a/libavcodec/packet.h
+++ b/libavcodec/packet.h
@@ -391,6 +391,8 @@ typedef struct AVPacket {
     attribute_deprecated
     int64_t convergence_duration;
 #endif
+
+    double gts;
 } AVPacket;
 
 typedef struct AVPacketList {

--- a/libavformat/avformat.h
+++ b/libavformat/avformat.h
@@ -2810,8 +2810,11 @@ void av_dump_format(AVFormatContext *ic,
  * @param flags AV_FRAME_FILENAME_FLAGS_*
  * @return 0 if OK, -1 on format error
  */
+int av_get_frame_filename3(char *buf, int buf_size,
+                          const char *path, int number, int flags, int64_t ts, double duration, double global_timestamp);
+
 int av_get_frame_filename2(char *buf, int buf_size,
-                          const char *path, int number, int flags);
+                          const char *path, int number, int flags, int64_t ts);
 
 int av_get_frame_filename(char *buf, int buf_size,
                           const char *path, int number);

--- a/libavformat/hls.c
+++ b/libavformat/hls.c
@@ -34,6 +34,7 @@
 #include "libavutil/opt.h"
 #include "libavutil/dict.h"
 #include "libavutil/time.h"
+#include "libavutil/time_internal.h"
 #include "avformat.h"
 #include "internal.h"
 #include "avio_internal.h"
@@ -75,6 +76,8 @@ struct segment {
     uint8_t iv[16];
     /* associated Media Initialization Section, treated as a segment */
     struct segment *init_section;
+    double program_date_time;
+    int64_t initial_dts;
 };
 
 struct rendition;
@@ -723,6 +726,7 @@ static int parse_playlist(HLSContext *c, const char *url,
     struct segment **prev_segments = NULL;
     int prev_n_segments = 0;
     int64_t prev_start_seq_no = -1;
+    double program_date_time = -1;
 
     if (is_http && !in && c->http_persistent && c->playlist_pb) {
         in = c->playlist_pb;
@@ -872,6 +876,28 @@ static int parse_playlist(HLSContext *c, const char *url,
             ptr = strchr(ptr, '@');
             if (ptr)
                 seg_offset = strtoll(ptr+1, NULL, 10);
+        } else if (av_strstart(line, "#EXT-X-PROGRAM-DATE-TIME:", &ptr)) {
+            struct tm pdt;
+            int y,M,d,h,m;
+            double s;
+
+            // TODO: take timezone into consideration
+            if (sscanf(ptr, "%d-%d-%dT%d:%d:%lf", &y, &M, &d, &h, &m, &s) != 6) {
+                ret = AVERROR_INVALIDDATA;
+                goto fail;
+            }
+
+            pdt.tm_year = y - 1900;
+            pdt.tm_mon = M - 1;
+            pdt.tm_mday = d;
+            pdt.tm_hour = h;
+            pdt.tm_min = m;
+            pdt.tm_sec = 0;
+            pdt.tm_isdst = -1;
+
+            program_date_time = ff_timegm(&pdt);
+            program_date_time += s;
+            // TODO: avoid rounding errors by tracking ms separately
         } else if (av_strstart(line, "#", NULL)) {
             av_log(c->ctx, AV_LOG_INFO, "Skip ('%s')\n", line);
             continue;
@@ -941,6 +967,13 @@ static int parse_playlist(HLSContext *c, const char *url,
                 }
                 seg->duration = duration;
                 seg->key_type = key_type;
+
+                seg->program_date_time = program_date_time;
+                if (program_date_time > 0) {
+                    program_date_time += (double) duration / AV_TIME_BASE;
+                }
+                seg->initial_dts = -1;
+
                 dynarray_add(&pls->segments, &pls->n_segments, seg);
                 is_segment = 0;
 
@@ -992,8 +1025,20 @@ fail:
     return ret;
 }
 
+static struct segment *closest_segment(struct playlist *pls) {
+    int n = pls->cur_seq_no - pls->start_seq_no;
+    if (n < 0)
+        return pls->segments[0];
+    if (n >= pls->n_segments)
+        return pls->segments[pls->n_segments - 1];
+    return pls->segments[pls->cur_seq_no - pls->start_seq_no];
+}
+
 static struct segment *current_segment(struct playlist *pls)
 {
+    int n = pls->cur_seq_no - pls->start_seq_no;
+    if (n >= pls->n_segments)
+        return NULL;
     return pls->segments[pls->cur_seq_no - pls->start_seq_no];
 }
 
@@ -2163,6 +2208,17 @@ static int hls_read_packet(AVFormatContext *s, AVPacket *pkt)
                         return ret;
                     break;
                 } else {
+                    struct segment *seg = closest_segment(pls);
+                    if (seg->initial_dts < 0 && pls->pkt.dts != AV_NOPTS_VALUE) {
+                        seg->initial_dts = pls->pkt.dts;
+                    }
+
+                    if (pls->pkt.pts != AV_NOPTS_VALUE && seg->program_date_time > 0 && seg->initial_dts > 0) {
+                        pls->pkt.gts = seg->program_date_time + (pls->pkt.pts - seg->initial_dts) * av_q2d(get_timebase(pls));
+                    } else {
+                        pls->pkt.gts = -1;
+                    }
+
                     /* stream_index check prevents matching picture attachments etc. */
                     if (pls->is_id3_timestamped && pls->pkt.stream_index == 0) {
                         /* audio elementary streams are id3 timestamped */

--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdint.h>
+#include <ctype.h>
 
 #include "config.h"
 
@@ -4701,10 +4702,17 @@ uint64_t ff_get_formatted_ntp_time(uint64_t ntp_time_us)
     return ntp_ts;
 }
 
-int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number, int flags)
+int av_get_frame_filename2(char *buf, int buf_size, const char *path,
+                           int number, int flags, int64_t ts)
+{
+    return av_get_frame_filename3(buf, buf_size, path, number, flags, ts, 0, -1);
+}
+
+int av_get_frame_filename3(char *buf, int buf_size, const char *path,
+                           int number, int flags, int64_t ts, double duration, double global_timestamp)
 {
     const char *p;
-    char *q, buf1[20], c;
+    char *q, buf1[32], c;
     int nd, len, percentd_found;
 
     q = buf;
@@ -4741,6 +4749,41 @@ int av_get_frame_filename2(char *buf, int buf_size, const char *path, int number
                 memcpy(q, buf1, len);
                 q += len;
                 break;
+            case 't':
+                if (!(flags & AV_FRAME_FILENAME_FLAGS_MULTIPLE) && percentd_found)
+                    goto fail;
+                percentd_found = 1;
+                int64_t seconds   = ts / AV_TIME_BASE;
+                int64_t microsecs = ts % AV_TIME_BASE;
+                snprintf(buf1, sizeof(buf1), "%010" PRId64 ".%06" PRId64, seconds, microsecs);
+                len = strlen(buf1);
+                if ((q - buf + len) > buf_size - 1)
+                    goto fail;
+                memcpy(q, buf1, len);
+                q += len;
+                break;
+            case 'l':
+                if (!(flags & AV_FRAME_FILENAME_FLAGS_MULTIPLE) && percentd_found)
+                    goto fail;
+                percentd_found = 1;
+                snprintf(buf1, sizeof(buf1), "%017.6f", duration);
+                len = strlen(buf1);
+                if ((q - buf + len) > buf_size - 1)
+                    goto fail;
+                memcpy(q, buf1, len);
+                q += len;
+                break;
+            case 'g':
+                if (!(flags & AV_FRAME_FILENAME_FLAGS_MULTIPLE) && percentd_found)
+                    goto fail;
+                percentd_found = 1;
+                snprintf(buf1, sizeof(buf1), "%017.6f", global_timestamp);
+                len = strlen(buf1);
+                if ((q - buf + len) > buf_size - 1)
+                    goto fail;
+                memcpy(q, buf1, len);
+                q += len;
+                break;
             default:
                 goto fail;
             }
@@ -4761,7 +4804,7 @@ fail:
 
 int av_get_frame_filename(char *buf, int buf_size, const char *path, int number)
 {
-    return av_get_frame_filename2(buf, buf_size, path, number, 0);
+    return av_get_frame_filename2(buf, buf_size, path, number, 0, 0);
 }
 
 void av_url_split(char *proto, int proto_size,

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -173,7 +173,6 @@ OBJS = adler32.o                                                        \
        video_enc_params.o                                               \
        film_grain_params.o                                              \
 
-
 OBJS-$(CONFIG_CUDA)                     += hwcontext_cuda.o
 OBJS-$(CONFIG_D3D11VA)                  += hwcontext_d3d11va.o
 OBJS-$(CONFIG_DXVA2)                    += hwcontext_dxva2.o

--- a/libavutil/frame.c
+++ b/libavutil/frame.c
@@ -164,6 +164,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
     frame->color_range         = AVCOL_RANGE_UNSPECIFIED;
     frame->chroma_location     = AVCHROMA_LOC_UNSPECIFIED;
     frame->flags               = 0;
+    frame->gts                 = -1;
 }
 
 static void free_side_data(AVFrameSideData **ptr_sd)
@@ -386,6 +387,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
     dst->colorspace             = src->colorspace;
     dst->color_range            = src->color_range;
     dst->chroma_location        = src->chroma_location;
+    dst->gts                    = src->gts;
 
     av_dict_copy(&dst->metadata, src->metadata, 0);
 

--- a/libavutil/frame.h
+++ b/libavutil/frame.h
@@ -691,6 +691,8 @@ typedef struct AVFrame {
      * for the target frame's private_ref field.
      */
     AVBufferRef *private_ref;
+
+    double gts;
 } AVFrame;
 
 #if FF_API_FRAME_GET_SET

--- a/libavutil/time.c
+++ b/libavutil/time.c
@@ -96,3 +96,20 @@ int av_usleep(unsigned usec)
     return AVERROR(ENOSYS);
 #endif
 }
+
+size_t av_strftime_micro(char *buf, size_t size, const char *format, const struct timeval *tv)
+{
+  struct tm *tm;
+  char *temp_name = av_malloc(size);
+  if (!temp_name)
+    return 0;
+
+  if (!(tm = localtime(&(tv->tv_sec))))
+    return 0;
+
+  strftime(temp_name, size, format, tm);
+  size_t retval = snprintf(buf, size, temp_name, tv->tv_usec);
+
+  av_free(temp_name);
+  return retval;
+}

--- a/libavutil/time.h
+++ b/libavutil/time.h
@@ -21,6 +21,7 @@
 #ifndef AVUTIL_TIME_H
 #define AVUTIL_TIME_H
 
+#include "mem.h"
 #include <stdint.h>
 
 /**
@@ -52,5 +53,15 @@ int av_gettime_relative_is_monotonic(void);
  * @return zero on success or (negative) error code.
  */
 int av_usleep(unsigned usec);
+
+/**
+ * Linux strftime function with micro second accuracy
+ * @param buf    char buffer to write output
+ * @param size   max number of bytes
+ * @param format format string, identical to the one for strftime
+ * @param tv     timeval struct containing current time
+ * @return number of bytes written
+ */
+size_t av_strftime_micro(char *buf, size_t size, const char *format, const struct timeval *tv);
 
 #endif /* AVUTIL_TIME_H */

--- a/libavutil/time_internal.h
+++ b/libavutil/time_internal.h
@@ -20,6 +20,9 @@
 #define AVUTIL_TIME_INTERNAL_H
 
 #include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "config.h"
 
 #if !HAVE_GMTIME_R && !defined(gmtime_r)
@@ -45,5 +48,25 @@ static inline struct tm *ff_localtime_r(const time_t* clock, struct tm *result)
 }
 #define localtime_r ff_localtime_r
 #endif
+
+static inline time_t ff_timegm(struct tm *tm)
+{
+  time_t ret;
+  char *tz;
+
+  tz = getenv("TZ");
+  if (tz)
+      tz = strdup(tz);
+  setenv("TZ", "", 1);
+  tzset();
+  ret = mktime(tm);
+  if (tz) {
+      setenv("TZ", tz, 1);
+      free(tz);
+  } else
+      unsetenv("TZ");
+  tzset();
+  return ret;
+}
 
 #endif /* AVUTIL_TIME_INTERNAL_H */


### PR DESCRIPTION
* Support micro seconds for image2 strftime filename
* Support micro seconds for segment strftime filename
* Support duration for segment output
* Allow split on keyframe with NOPTS
* Add EXT-X-PROGRAM-DATE-TIME parsing to hls.c
* Add global timestamp (gts) metatdata to AVPacket and AVFrame
* Support gts for image2 filename
* Support gts for segment filename

Signed-off-by: tak-matroid <tak@matroid.com>